### PR TITLE
Fix link in table for property

### DIFF
--- a/public_html/index.php
+++ b/public_html/index.php
@@ -168,7 +168,7 @@ if (!isset($_REQUEST['p'])) { ?>
 	foreach ($result as $row) {
 		if ($row[1] == 0) {
 			$row[1] = "\n<div class=\"ui ribbon label\">All values</div>\n";
-			$row[0] = "<a href=\"https://wikidata.org/wiki/P" . $row[0] . "\">P". $row[0] . "</a>";
+			$row[0] = "<a href=\"https://wikidata.org/wiki/Property:P" . $row[0] . "\">P". $row[0] . "</a>";
 		} else {
 			$row[1] = "Q" . $row[1];
 			$row[0] = "P" . $row[0];


### PR DESCRIPTION
The link created by index.php to the property at wikidata.org does not work as the property namespace is missing 'Property:', see, e.g., https://tools.wmflabs.org/wd-analyst/index.php?p=P180

I did no testing of the patch 
